### PR TITLE
feature/neorv32-gnu-toolchain: riscv-gnu-toolchain for neorv32

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -6,6 +6,7 @@
 {
   baibot = pkgs.callPackage ./baibot { };
   cppman = pkgs.callPackage ./cppman { };
+  neorv32-gnu-toolchain = pkgs.callPackage ./neorv32-gnu-toolchain { };
   pyman = pkgs.callPackage ./pyman { };
   synapse_change_display_name = pkgs.callPackage ./synapse_change_display_name { };
   visual-paradigm-community = pkgs.callPackage ./visual-paradigm-community { };

--- a/pkgs/neorv32-gnu-toolchain/default.nix
+++ b/pkgs/neorv32-gnu-toolchain/default.nix
@@ -1,0 +1,104 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  autoconf,
+  automake,
+  # autotools-dev,
+  bc,
+  bison,
+  cmake,
+  curl,
+  flex,
+  gawk,
+  git,
+  glib,
+  gmp,
+  gperf,
+  expat, # libexpat,
+  libmpc,
+  mpfr, # libmpfr,
+  libtool,
+  ninja,
+  patchutils,
+  python3,
+  # slirp,
+  texinfo,
+  zlib,
+  coreutils,
+  util-linux,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "neorv32-gnu-toolchain";
+  version = "2025.06.13";
+
+  src = fetchFromGitHub {
+    owner = "riscv-collab";
+    repo = "riscv-gnu-toolchain";
+    rev = version;
+    hash = "sha256-alizCErkGot6tOtRDrQj7T1zKcNnmfcp4QUc0jgms78=";
+    fetchSubmodules = true;
+  };
+
+  patches = [
+    ./disable-git-submodule.patch
+  ];
+
+  buildInputs = [
+    autoconf
+    automake
+    curl
+    python3
+    libmpc
+    mpfr
+    gmp
+    gawk
+    bison
+    flex
+    texinfo
+    gperf
+    libtool
+    patchutils
+    bc
+    zlib
+    expat
+    ninja
+    git
+    cmake
+    glib
+    (python3.withPackages (p: with p; [ pip ]))
+    coreutils
+    util-linux
+  ];
+
+  preConfigure = ''
+    export PATH=${coreutils}/bin:${util-linux}/bin:$PATH
+    chmod +x ./scripts/*
+    chmod +x ./scripts/wrapper/*
+  '';
+
+  configurePhase = ''
+    ./configure \
+      --prefix=$out \
+      --with-arch=rv32i_zicsr_zicntr \
+      --with-abi=ilp32
+  '';
+
+  buildPhase = ''
+    make
+  '';
+
+  installPhase = ''
+    make install
+  '';
+
+  meta = {
+    description = "GNU toolchain for RISC-V, including GCC";
+    homepage = "https://github.com/riscv-collab/riscv-gnu-toolchain";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/neorv32-gnu-toolchain/disable-git-submodule.patch
+++ b/pkgs/neorv32-gnu-toolchain/disable-git-submodule.patch
@@ -1,0 +1,14 @@
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -339,11 +339,6 @@
+ GCCPKGVER :=
+ endif
+ 
+-$(srcdir)/%/.git:
+-	cd $(srcdir) && \
+-	flock `git rev-parse --git-dir`/config git submodule init $(dir $@) && \
+-	flock `git rev-parse --git-dir`/config git submodule update --progress --depth 1 $(dir $@)
+-
+ stamps/install-host-gcc: $(GCC_SRCDIR) $(GCC_SRC_GIT)
+ 	if test -f $</contrib/download_prerequisites && test "@NEED_GCC_EXTERNAL_LIBRARIES@" = "true"; then cd $< && ./contrib/download_prerequisites; fi
+ 	rm -rf $@ $(notdir $@)


### PR DESCRIPTION
A Nix package compiling [riscv-gnu-toolchain](https://github.com/riscv-collab/riscv-gnu-toolchain) for [NEORV32](https://github.com/stnolting/neorv32).

Fails to build:
```
error: builder for '/nix/store/15x5l51d58743y4df65z52mqy6dbapq7-neorv32-gnu-toolchain-2025.06.13.drv' failed with exit code 2;
       last 25 log lines:
       > checking whether the compiler supports GNU C... yes
       > checking whether gcc accepts -g... yes
       > checking for gcc option to enable C11 features... none needed
       > checking for grep that handles long lines and -e... /nix/store/gqmr3gixlddz3667ba1iyqck3c0dkpvd-gnugrep-3.11/bin/grep
       > checking for fgrep... /nix/store/gqmr3gixlddz3667ba1iyqck3c0dkpvd-gnugrep-3.11/bin/grep -F
       > checking for grep that handles long lines and -e... (cached) /nix/store/gqmr3gixlddz3667ba1iyqck3c0dkpvd-gnugrep-3.11/bin/grep
       > checking for bash... /nix/store/xy4jjgw87sbgwylm5kn047d9gkbhsr9x-bash-5.2p37/bin/bash
       > checking for __gmpz_init in -lgmp... yes
       > checking for mpfr_init in -lmpfr... yes
       > checking for mpc_init2 in -lmpc... yes
       > checking for curl... /nix/store/s2np0ri22gq9pq0fnv3yqjsbsbmw16xi-curl-8.13.0-bin/bin/curl
       > checking for wget... no
       > checking for ftp... no
       > configure: creating ./config.status
       > config.status: creating Makefile
       > config.status: creating scripts/wrapper/awk/awk
       > config.status: creating scripts/wrapper/sed/sed
       > Running phase: buildPhase
       > /bin/sh: which: not found
       > realpath: missing operand
       > Try 'realpath --help' for more information.
       > /bin/sh: which: not found
       > realpath: missing operand
       > Try 'realpath --help' for more information.
       > make: *** No rule to make target '/build/source/gcc/.git', needed by 'stamps/build-gcc-newlib-stage2'.  Stop.
```