### PR TITLE
Styling settings values substituted with mkDefault 

### DIFF
--- a/modules/home/styling/custom/hyprland/settings.nix
+++ b/modules/home/styling/custom/hyprland/settings.nix
@@ -5,10 +5,10 @@ let
 in
 {
   general = {
-    gaps_in = lib.mkDefault cfg.gaps / 2;
-    gaps_out = lib.mkDefault cfg.gaps;
+    gaps_in = lib.mkDefault (cfg.gaps / 2);
+    gaps_out = lib.mkDefault (cfg.gaps);
   };
   decoration = {
-    rounding = lib.mkDefault cfg.radius;
+    rounding = lib.mkDefault (cfg.radius);
   };
 }


### PR DESCRIPTION
Here we have the styling module setting the defaults of options from the hyprland module. 
https://github.com/sid115/nix-core/blob/55324479213a641bf20057efc9cae145a731f24e/modules/home/styling/custom/hyprland/settings.nix#L1-L14
At first I thought the according hyprland options were set with `mkDefault` but this isn't the case here. 
https://github.com/sid115/nix-core/blob/55324479213a641bf20057efc9cae145a731f24e/modules/home/hyprland/settings.nix#L27-L53
If there hasn't been a best practice for this repo yet it might be worth thinking about how to handle double default definitions which may occur in the future more frequently.
From what I have found out `lib.mkOptionDefault` with priority of 1500 might be a thing for the first layer of defaults then `lib.mkDefault` with 1000 and normal value override equals 100. Ofc people could just use `lib.mkForce` or the manual way `lib.mkOverride <value>` but it feels much more convenient to "just" override.