### PR TITLE
changed package name due to rename

### DIFF
--- a/modules/home/lf/default.nix
+++ b/modules/home/lf/default.nix
@@ -30,7 +30,7 @@ in
         hexyl
         glow
         chafa
-        poppler_utils
+        poppler-utils
         w3m
         ffmpeg
         ffmpegthumbnailer


### PR DESCRIPTION
error: 'poppler_utils' has been renamed to/replaced by 'poppler-utils'