### PR TITLE
fix/jellyfin-forceSSL: fixed mkIf for avoiding acme on localhost setup

### DIFF
--- a/modules/nixos/jellyfin/default.nix
+++ b/modules/nixos/jellyfin/default.nix
@@ -70,8 +70,8 @@ in
       locations."/".proxyPass = mkDefault "http://127.0.0.1:8096";
     };
 
-    security.acme.certs."${fqdn}".postRun = mkIf (
-      with cfg.reverseProxy; enable && forceSSL
-    ) "systemctl restart jellyfin.service";
+    security.acme.certs = mkIf (cfg.reverseProxy.enable && cfg.reverseProxy.forceSSL) {
+      "${fqdn}".postRun = "systemctl restart jellyfin.service";
+    };
   };
 }


### PR DESCRIPTION
The original issue:
```
Failed assertions:
       - You must define security.acme.certs.<name>.email or
       security.acme.defaults.email to register with the CA. Note that using
       many different addresses for certs may trigger account rate limits.
       - You must accept the CA's terms of service before using
       the ACME module by setting security.acme.acceptTerms
       to true. For Let's Encrypt's ToS see https://letsencrypt.org/repository/
       - Exactly one of the options
       security.acme.certs.media.negitorodon.de.dnsProvider,
       security.acme.certs.media.negitorodon.de.webroot,
       security.acme.certs.media.negitorodon.de.listenHTTP and
       security.acme.certs.media.negitorodon.de.s3Bucket
       is required.
       Current values: {
         dnsProvider = null;
         listenHTTP = null;
         s3Bucket = null;
         webroot = null;
       }
```
In my config I was setting this:
```
    services.jellyfin = {
      enable = true;
      reverseProxy = {
        subdomain = "media";
        forceSSL = false;
      };
      libraries = [
        "books/audiobooks"
        "movies"
        "music"
        "shows"
      ];
    };
  ```
  
  I simply sat the mkIf one level above to avoid acme being evaluated if there are no certs available due to localhost setup.