### PR TITLE
fix/oi-oci-network: internal network isolation removed

### DIFF
--- a/modules/nixos/open-webui-oci/default.nix
+++ b/modules/nixos/open-webui-oci/default.nix
@@ -131,7 +131,7 @@ in
       ];
       log-driver = "journald";
       extraOptions = [
-       "--network=host"
+        "--network=host"
       ];
     };
     systemd.services."podman-open-webui" = {


### PR DESCRIPTION
I experienced huge delays while sending and receiving messages to cheap non-reasoning models like gemini 2.5 flash and flash-lite. 21s it was ( I measured this with f12 over developer console, "network" and "Timing", message needed to be sent)  so firstly I tried to turn off buffer options from nginx which didn't help since after port forwarding to localhost the result remained. Secondly I was wondering why the extraOptions for the container were set as they were and merged podman and hostnetwork together with network=host. Therefore the port mapping needed to be removed. Currently default set port is 3000 and can be changed to whatever. 

https://youtu.be/VDuDQNkSC6g?si=6hVWEacxVop815LD&t=158